### PR TITLE
querying comment's post error resolved

### DIFF
--- a/graphql/resolvers/Comment/index.js
+++ b/graphql/resolvers/Comment/index.js
@@ -64,8 +64,8 @@ export default {
     author: async ({ author }, args, context, info) => {
       return await User.findById({ _id: author });
     },
-    post: async ({ _id }, args, context, info) => {
-      return await Post.findById(_id);
+    post: async ({ post }, args, context, info) => {
+      return await Post.findById({ _id: post });
     }
   }
 };


### PR DESCRIPTION
When you try to query 
`query{
  comments{
    text
    post{
      title
    }
  }
}`
there is an error showing 
`{
  "data": null,
  "errors": [
    {
      "message": "Cannot return null for non-nullable field Comment.post.",
      "locations": [
        {
          "line": 9,
          "column": 5
        }
      ],
      "path": [
        "comments",
        0,
        "post"
      ]
    }
  ]
}`
This pull requests resolves this error.